### PR TITLE
docs: add Cursor Cloud specific setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,15 @@
 
 This document provides essential information for AI agents working in the sockethub.org website repository.
 
+## Cursor Cloud specific instructions
+
+- **Build entry point is `build.js`, not `metalsmith.json`.** Older parts of this doc mention `metalsmith.json` / `npx metalsmith`; the real build is `npm run build` (which runs `node build.js`). `build.js` injects release-channel metadata from `release.json` before running Metalsmith, so building requires `release.json` to exist and reference a valid channel.
+- **Release channel:** the advertised version comes from `release.json` (`channel` field, currently `alpha`). Override at build time with `SOCKETHUB_CHANNEL=stable|alpha` (see `build:stable` / `build:alpha` scripts). An unknown channel makes `build.js` throw.
+- **Serving locally:** `npm run serve` serves the already-built `build/` directory with Python's `http.server` on port `8080`. It does NOT rebuild — run `npm run build` first (and after any source change) since there is no watch/live-reload.
+- **`build/` is tracked in git but auto-generated.** Every build rewrites `build/feed.xml` (and other files) with fresh timestamps, so `npm run build` will dirty the working tree. Do not commit `build/` changes from routine builds; `git checkout -- build/` to discard them. Deployment (`./deploy.sh`) publishes `build/` to `gh-pages` via git subtree and force-pushes — do not run it during normal dev.
+- **News content workflow (core functionality):** add `src/news/YYYY-MM-DD-slug.md` with frontmatter `date`, `title`, `collection: news`, `author`, rebuild, and the post appears at `/news/<slug>/`, in `/news/`, and in `/feed.xml`. Permalinks rewrite only news posts; other pages keep their source directory path.
+- No automated test suite or lint config exists; verify changes by building and loading pages (e.g. `curl` or the browser against `http://localhost:8080`).
+
 ## Project Overview
 
 This is a static website for sockethub.org built with **Metalsmith**, a static site generator. The site uses Handlebars templates, Markdown content, and generates a news feed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the sockethub.org Metalsmith static site, and documents durable, non-obvious startup notes for future cloud agents.

- Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` clarifying that the build is driven by `build.js` (not the `metalsmith.json` referenced elsewhere in the doc), the release-channel behavior, the no-rebuild `npm run serve` flow, and that `build/` is auto-generated (don't commit routine build churn).

No application/source code was modified.

## Environment setup

- Node `v22.14.0`, npm `10.9.7`
- `npm install` → 90 packages, build succeeds
- Update script for future VMs: `npm install`

## Testing

- `npm install` — dependencies installed
- `npm run build` — `[build] ok → ./build` (alpha channel, v5.0.0-alpha.13)
- `npm run serve` — static server on `:8080`; `/`, `/about/`, `/news/`, `/how-it-works/`, `/get-started/` return `200`; `/feed.xml` and `/sitemap.xml` return `200 application/xml`
- Core content workflow (hello world): created a temporary `src/news/*.md` post, rebuilt, and confirmed it rendered at `/news/cloud-env-smoke-test/`, appeared in the `/news/` listing and `/feed.xml`; then removed the temp post and rebuilt clean.

## Walkthrough

[sockethub_site_demo.mp4](https://cursor.com/agents/bc-bc0a7a19-c916-4add-95e7-464e7239d47a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsockethub_site_demo.mp4)

Homepage, news listing (with the temporary test post), the rendered post page, and the About page.

[Homepage rendered](https://cursor.com/agents/bc-bc0a7a19-c916-4add-95e7-464e7239d47a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_rendered.webp)
[News post rendered](https://cursor.com/agents/bc-bc0a7a19-c916-4add-95e7-464e7239d47a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnews_post_rendered.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc0a7a19-c916-4add-95e7-464e7239d47a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc0a7a19-c916-4add-95e7-464e7239d47a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

