### PR TITLE
feat: serve @sockethub/schemas artifacts at their canonical URLs

### DIFF
--- a/.github/workflows/deploy-schemas.yml
+++ b/.github/workflows/deploy-schemas.yml
@@ -1,0 +1,160 @@
+name: Deploy schema artifacts
+
+# Serve the published @sockethub/schemas artifacts at their canonical
+# sockethub.org $id / @context URLs (see issue sockethub/sockethub#1185).
+#
+# Triggered by a repository_dispatch fired from the core repo's release-publish
+# workflow once a release is published to npm. The core repo only needs a
+# trigger-scoped token; all writes here use this repo's own GITHUB_TOKEN.
+#
+# Can also be run manually (workflow_dispatch) to backfill a historical version
+# or re-run a failed deploy.
+on:
+  repository_dispatch:
+    types: [deploy-schemas]
+  workflow_dispatch:
+    inputs:
+      schemas_version:
+        description: "@sockethub/schemas version to publish (e.g. 3.0.0-alpha.16)"
+        required: true
+        type: string
+      release_version:
+        description: "Sockethub server release version to advertise (e.g. 5.0.0-alpha.16)"
+        required: false
+        type: string
+      channel:
+        description: "Release channel whose advertised version to bump"
+        required: false
+        type: string
+
+# Never let two deploys race the gh-pages force-push.
+concurrency:
+  group: deploy-schemas
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve inputs
+        id: inputs
+        env:
+          # repository_dispatch carries values under client_payload; a manual
+          # run carries them under inputs. Coalesce to one set of outputs.
+          SCHEMAS_VERSION: ${{ github.event.client_payload.schemas_version || inputs.schemas_version }}
+          RELEASE_VERSION: ${{ github.event.client_payload.release_version || inputs.release_version }}
+          CHANNEL: ${{ github.event.client_payload.channel || inputs.channel }}
+        run: |
+          if [ -z "$SCHEMAS_VERSION" ]; then
+            echo "::error::schemas_version is required"
+            exit 1
+          fi
+          echo "schemas_version=$SCHEMAS_VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "📦 schemas=$SCHEMAS_VERSION release=$RELEASE_VERSION channel=$CHANNEL"
+
+      - name: Checkout site (master)
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          # Full history so `git subtree split` can build the gh-pages tree.
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Sync published schema artifacts into src/
+        run: |
+          node scripts/sync-schemas.mjs "${{ steps.inputs.outputs.schemas_version }}" --alias-latest
+
+      - name: Bump advertised version (release.json)
+        if: steps.inputs.outputs.channel != '' && steps.inputs.outputs.release_version != ''
+        run: |
+          node scripts/set-channel-version.mjs \
+            "${{ steps.inputs.outputs.channel }}" \
+            "${{ steps.inputs.outputs.release_version }}"
+
+      # If neither the synced artifacts nor release.json changed, there is
+      # nothing to publish (e.g. a server-only release where @sockethub/schemas
+      # did not bump, re-running an already-synced version). Skip the rebuild
+      # and deploy entirely so we don't force-push an identical gh-pages tree.
+      - name: Detect changes
+        id: changes
+        run: |
+          git add -A src release.json
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "✅ Nothing new to publish; skipping build & deploy."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Changed files:"
+            git diff --cached --name-only | sed 's/^/  /'
+          fi
+
+      - name: Build site
+        if: steps.changes.outputs.changed == 'true'
+        run: npm run build
+
+      - name: Commit source + build
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A src release.json build
+          git commit -m "chore: publish @sockethub/schemas@${{ steps.inputs.outputs.schemas_version }} artifacts"
+          git push origin HEAD:master
+
+      - name: Deploy build/ to gh-pages
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          # Same publish mechanism as ./deploy.sh: split the build/ subtree and
+          # force-push it as the gh-pages root (served by GitHub Pages).
+          git push origin "$(git subtree split --prefix build/ HEAD)":gh-pages --force
+
+      - name: Smoke-test live URLs
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          set -u
+          VER="${{ steps.inputs.outputs.schemas_version }}"
+
+          # Prefer the versioned config schema (the primary acceptance target);
+          # fall back to the always-present base context for pre-config-schema
+          # releases that ship no top-level JSON schemas.
+          if [ -f "build/schemas/$VER/sockethub-config.json" ]; then
+            URL="https://sockethub.org/schemas/$VER/sockethub-config.json"
+            EXPECT_ID="$URL"
+          else
+            URL="https://sockethub.org/ns/context/v1.jsonld"
+            EXPECT_ID=""
+          fi
+          echo "Verifying $URL (GitHub Pages may take a minute to update)…"
+
+          for attempt in $(seq 1 30); do
+            BODY="$(curl -fsSL "$URL" 2>/dev/null || true)"
+            if [ -n "$BODY" ]; then
+              if [ -z "$EXPECT_ID" ]; then
+                echo "✅ $URL is live"
+                exit 0
+              fi
+              GOT_ID="$(printf '%s' "$BODY" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(JSON.parse(s).$id||"")}catch{}})')"
+              if [ "$GOT_ID" = "$EXPECT_ID" ]; then
+                echo "✅ $URL is live and \$id matches"
+                exit 0
+              fi
+              echo "  fetched but \$id not yet matching (got '$GOT_ID'); Pages still updating…"
+            else
+              echo "  not reachable yet (attempt $attempt/30)…"
+            fi
+            sleep 20
+          done
+          echo "::error::$URL did not become live/correct within timeout"
+          exit 1

--- a/scripts/set-channel-version.mjs
+++ b/scripts/set-channel-version.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Update the advertised version for one release channel in release.json.
+ *
+ * The deploy-schemas workflow calls this with the server release version so the
+ * site's advertised version tracks releases automatically. It only touches the
+ * version of the named channel — it never flips the active `channel` (promoting
+ * alpha -> stable stays an editorial decision).
+ *
+ * Usage: node scripts/set-channel-version.mjs <channel> <version>
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const RELEASE_JSON = join(ROOT, "release.json");
+
+const [channel, version] = process.argv.slice(2);
+if (!channel || !version) {
+    console.error("usage: set-channel-version.mjs <channel> <version>");
+    process.exit(1);
+}
+
+const data = JSON.parse(readFileSync(RELEASE_JSON, "utf8"));
+if (!data.channels?.[channel]) {
+    console.error(
+        `set-channel-version: unknown channel "${channel}" (have: ${Object.keys(
+            data.channels ?? {},
+        ).join(", ")})`,
+    );
+    process.exit(1);
+}
+
+if (data.channels[channel].version === version) {
+    console.log(`release.json: ${channel} already at ${version}`);
+    process.exit(0);
+}
+
+data.channels[channel].version = version;
+writeFileSync(RELEASE_JSON, `${JSON.stringify(data, null, 2)}\n`);
+console.log(`release.json: ${channel} -> ${version}`);

--- a/scripts/sync-schemas.mjs
+++ b/scripts/sync-schemas.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/**
+ * Sync the published @sockethub/schemas artifacts into this site's `src/` tree
+ * at the exact URL paths their `$id` / `@context` URLs already point at, so
+ * sockethub.org actually serves them.
+ *
+ * The generated artifacts bake absolute sockethub.org URLs into themselves
+ * (JSON Schema `$id`, JSON-LD `@context`). The npm `dist/` layout does NOT
+ * mirror those URLs — there are three distinct URL prefixes and the platform
+ * dir names are percent-encoded for tarball portability. This script performs
+ * the dist -> URL mapping and decoding:
+ *
+ *   dist/schemas/json/<name>.json      -> src/schemas/<version>/<name>.json
+ *   dist/contexts/<path>               -> src/ns/context/<path>
+ *   dist/schemas/platform/<path>       -> src/schemas/as2/platform/<path>
+ *
+ * Each path segment is percent-decoded, so the on-disk `sockethub%3Ainternal`
+ * (kept encoded in the tarball so `npm install` works on Windows) is served at
+ * its canonical `.../platform/sockethub:internal/...` URL.
+ *
+ * `dist/maps/context-map.json` is intentionally NOT served — it's an internal
+ * runtime lookup consumed from the npm package, not referenced by any URL.
+ *
+ * Idempotency is handled by git: re-running with an already-synced version
+ * simply produces no diff, so the deploy workflow commits nothing.
+ *
+ * Usage:
+ *   node scripts/sync-schemas.mjs <version> [options]
+ *
+ * Options:
+ *   --tarball <path>   Use a local .tgz instead of `npm pack` (for CI-from-source / testing)
+ *   --alias-latest     Also copy the versioned top-level schemas to src/schemas/v/
+ *                      (the unversioned `/v/` placeholder -> latest)
+ *   --dry-run          Print the planned copies without writing anything
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+    cpSync,
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readdirSync,
+    readFileSync,
+    rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function parseArgs(argv) {
+    const opts = { alias: false, dryRun: false, tarball: null, version: null };
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        if (arg === "--alias-latest") opts.alias = true;
+        else if (arg === "--dry-run") opts.dryRun = true;
+        else if (arg === "--tarball") opts.tarball = argv[++i];
+        else if (arg.startsWith("--"))
+            fail(`unknown option: ${arg}`);
+        else if (!opts.version) opts.version = arg;
+        else fail(`unexpected argument: ${arg}`);
+    }
+    if (!opts.version) fail("missing <version> argument");
+    return opts;
+}
+
+function fail(msg) {
+    console.error(`sync-schemas: ${msg}`);
+    process.exit(1);
+}
+
+/**
+ * Fetch and extract the published package tarball, returning its `dist/` dir.
+ * Retries `npm pack` a few times to ride out npm registry propagation lag right
+ * after a release (the same reason the Docker publish job retries).
+ */
+function extractDist(version, tarballOverride, workDir) {
+    let tgz = tarballOverride;
+    if (!tgz) {
+        const spec = `@sockethub/schemas@${version}`;
+        let lastErr;
+        for (let attempt = 1; attempt <= 10; attempt++) {
+            try {
+                const out = execFileSync(
+                    "npm",
+                    ["pack", spec, "--pack-destination", workDir, "--silent"],
+                    { encoding: "utf8" },
+                );
+                tgz = join(workDir, out.trim().split("\n").pop());
+                break;
+            } catch (err) {
+                lastErr = err;
+                console.warn(
+                    `  npm pack ${spec} failed (attempt ${attempt}/10); registry may still be propagating…`,
+                );
+                sleep(20_000);
+            }
+        }
+        if (!tgz) throw lastErr;
+    }
+    if (!existsSync(tgz)) fail(`tarball not found: ${tgz}`);
+    execFileSync("tar", ["-xzf", tgz, "-C", workDir]);
+    const dist = join(workDir, "package", "dist");
+    if (!existsSync(dist)) fail(`tarball has no package/dist (got ${tgz})`);
+    return dist;
+}
+
+function sleep(ms) {
+    // Busy-free blocking sleep without pulling in async in a linear script.
+    execFileSync("sleep", [String(Math.ceil(ms / 1000))]);
+}
+
+/** Decode every segment of a relative posix path. */
+function decodePath(relPath) {
+    return relPath
+        .split("/")
+        .map((seg) => decodeURIComponent(seg))
+        .join("/");
+}
+
+/** Recursively list files under `dir`, returned as paths relative to `dir`. */
+function listFiles(dir, base = dir) {
+    const result = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) result.push(...listFiles(full, base));
+        else if (entry.isFile())
+            result.push(full.slice(base.length + 1));
+    }
+    return result;
+}
+
+function copyFile(src, dest, dryRun) {
+    console.log(
+        `  ${dest.slice(ROOT.length + 1)}${dryRun ? "  (dry-run)" : ""}`,
+    );
+    if (dryRun) return;
+    mkdirSync(dirname(dest), { recursive: true });
+    cpSync(src, dest);
+}
+
+function syncTree(srcRoot, destRoot, { decode, dryRun }) {
+    if (!existsSync(srcRoot)) return 0;
+    const files = listFiles(srcRoot);
+    for (const rel of files) {
+        const destRel = decode ? decodePath(rel) : rel;
+        copyFile(join(srcRoot, rel), join(destRoot, destRel), dryRun);
+    }
+    return files.length;
+}
+
+/**
+ * Assert every top-level schema's baked `$id` matches the version dir it will
+ * be served from: https://sockethub.org/schemas/<version>/<basename>.
+ */
+function assertVersionedIds(jsonDir, version) {
+    for (const name of readdirSync(jsonDir)) {
+        if (!name.endsWith(".json")) continue;
+        const doc = JSON.parse(readFileSync(join(jsonDir, name), "utf8"));
+        const want = `https://sockethub.org/schemas/${version}/${name}`;
+        if (doc.$id !== want) {
+            fail(
+                `$id mismatch in ${name}: expected "${want}" but schema declares "${doc.$id}". ` +
+                    `Refusing to serve a schema at a URL its $id disagrees with.`,
+            );
+        }
+    }
+}
+
+function main() {
+    const opts = parseArgs(process.argv.slice(2));
+    const { version, tarball, alias, dryRun } = opts;
+
+    console.log(`sync-schemas: @sockethub/schemas@${version}`);
+    const workDir = mkdtempSync(join(tmpdir(), "sh-schemas-"));
+    try {
+        const dist = extractDist(version, tarball, workDir);
+
+        // 1. Versioned top-level JSON schemas -> /schemas/<version>/
+        //    (absent in pre-config-schema releases; warn and continue).
+        const jsonDir = join(dist, "schemas", "json");
+        const versionedDest = join(ROOT, "src", "schemas", version);
+        let jsonCount = 0;
+        if (existsSync(jsonDir)) {
+            console.log(`versioned schemas -> src/schemas/${version}/`);
+            // Fail loudly if a schema's baked `$id` disagrees with the version
+            // dir it's about to be served from — that would publish a schema at
+            // a URL whose `$id` points somewhere else (the exact silent drift
+            // this whole feature exists to prevent).
+            assertVersionedIds(jsonDir, version);
+            jsonCount = syncTree(jsonDir, versionedDest, { decode: false, dryRun });
+        } else {
+            console.warn(
+                `  note: this version has no dist/schemas/json (pre-config-schema build); skipping versioned schemas`,
+            );
+        }
+
+        // 2. JSON-LD contexts -> /ns/context/  (decode encoded platform segs)
+        console.log(`contexts -> src/ns/context/`);
+        const ctxCount = syncTree(
+            join(dist, "contexts"),
+            join(ROOT, "src", "ns", "context"),
+            { decode: true, dryRun },
+        );
+
+        // 3. Per-platform message/credentials schemas -> /schemas/as2/platform/
+        console.log(`platform schemas -> src/schemas/as2/platform/`);
+        const platCount = syncTree(
+            join(dist, "schemas", "platform"),
+            join(ROOT, "src", "schemas", "as2", "platform"),
+            { decode: true, dryRun },
+        );
+
+        // 4. Optional unversioned `/v/` alias -> copy of the latest top-level schemas.
+        if (alias && existsSync(jsonDir)) {
+            console.log(`alias -> src/schemas/v/  (unversioned -> latest)`);
+            const aliasDest = join(ROOT, "src", "schemas", "v");
+            if (existsSync(aliasDest) && !dryRun)
+                rmSync(aliasDest, { recursive: true, force: true });
+            syncTree(jsonDir, aliasDest, { decode: false, dryRun });
+        }
+
+        console.log(
+            `sync-schemas: done (${jsonCount} versioned, ${ctxCount} contexts, ${platCount} platform schemas)`,
+        );
+    } finally {
+        rmSync(workDir, { recursive: true, force: true });
+    }
+}
+
+main();


### PR DESCRIPTION
Companion to sockethub/sockethub#1187. Together they close sockethub/sockethub#1185.

## Problem
`@sockethub/schemas` bakes absolute `sockethub.org` URLs into its artifacts (`$id` for JSON Schemas, `@context` for JSON-LD), but sockethub.org serves none of them — every one is a 404. `sockethub --write-config` now stamps `$schema: https://sockethub.org/schemas/<version>/sockethub-config.json` into generated configs, so editors fetch a 404 instead of validating.

## What this PR does (serving side)
Adds the first CI to this repo plus two scripts:

- **`scripts/sync-schemas.mjs`** — `npm pack @sockethub/schemas@<ver>`, extract, and lay artifacts into URL-mirrored `src/` paths. The npm `dist/` layout does **not** mirror the public URLs, so it remaps three prefixes and **percent-decodes** path segments (the tarball keeps `sockethub%3Ainternal` encoded for Windows `npm install`; it's served at its canonical `.../platform/sockethub:internal/...` URL). Fails loudly if a schema's baked `$id` disagrees with the version dir it's served from. Metalsmith passes the `.json`/`.jsonld` files through `src/` → `build/` untouched, and git preserves every historical version.
- **`scripts/set-channel-version.mjs`** — bump the advertised version in `release.json` for a channel (it's stale today).
- **`.github/workflows/deploy-schemas.yml`** — on `repository_dispatch` from the core release workflow (payload: `schemas_version`, `release_version`, `channel`) or manual `workflow_dispatch`: sync → bump → **skip if nothing changed** → `npm run build` → commit `src`+`build` → force-push the `build/` subtree to `gh-pages` → **smoke-test the live URL** (asserts `$id` matches). All writes use this repo's own `GITHUB_TOKEN`.

## Notes
- Historical versions accumulate as committed `src/schemas/<version>/` dirs — configs pin a version forever.
- `.json` is served by GitHub Pages as `application/json` with `Access-Control-Allow-Origin: *` (editor validation + browser JSON-LD fetches work). `.jsonld` contexts serve as `octet-stream`, which JSON-LD processors tolerate.
- This PR adds only the tooling; the actual versioned artifacts land automatically on the first release dispatch (or a manual `workflow_dispatch`).

Tested locally end-to-end: sync against real npm `alpha.15` and a local pack of the config-schema branch, `release.json` bump, change-detection, `npm run build`, and confirming every served path (including the colon path and `/v/` alias) lands in `build/`.